### PR TITLE
Feat/token permit

### DIFF
--- a/Scarb.lock
+++ b/Scarb.lock
@@ -196,6 +196,7 @@ dependencies = [
  "openzeppelin_security",
  "openzeppelin_token",
  "openzeppelin_upgrades",
+ "openzeppelin_utils",
  "registry",
  "roles",
  "snforge_std",

--- a/crates/token/Scarb.toml
+++ b/crates/token/Scarb.toml
@@ -9,6 +9,7 @@ openzeppelin_access.workspace = true
 openzeppelin_token.workspace = true
 openzeppelin_security.workspace = true
 openzeppelin_upgrades.workspace = true
+openzeppelin_utils.workspace = true
 onchain_id_starknet.workspace = true
 registry = {path = "../registry"}
 roles = { path = "../roles"}

--- a/crates/token/src/itoken.cairo
+++ b/crates/token/src/itoken.cairo
@@ -53,7 +53,7 @@ pub trait IToken<TContractState> {
         ref self: TContractState, user_addresses: Span<ContractAddress>, amounts: Span<u256>,
     );
     fn onchain_id(self: @TContractState) -> ContractAddress;
-    fn version(self: @TContractState) -> ByteArray;
+    fn version(self: @TContractState) -> felt252;
     fn identity_registry(self: @TContractState) -> IIdentityRegistryDispatcher;
     fn compliance(self: @TContractState) -> IModularComplianceDispatcher;
     fn is_frozen(self: @TContractState, user_address: ContractAddress) -> bool;

--- a/crates/token/src/token.cairo
+++ b/crates/token/src/token.cairo
@@ -55,6 +55,8 @@ pub mod Token {
 
     impl UpgradeableInternalImpl = UpgradeableComponent::InternalImpl<ContractState>;
 
+    pub const TOKEN_VERSION: felt252 = '0.1.0';
+
     #[storage]
     struct Storage {
         token_decimals: u8,
@@ -106,7 +108,7 @@ pub mod Token {
         #[key]
         pub new_symbol: ByteArray,
         pub new_decimals: u8,
-        pub new_version: ByteArray,
+        pub new_version: felt252,
         #[key]
         pub new_onchain_id: ContractAddress,
     }
@@ -216,7 +218,7 @@ pub mod Token {
                         new_name: name,
                         new_symbol: self.erc20.ERC20_symbol.read(),
                         new_decimals: self.token_decimals.read(),
-                        new_version: self.token_version.read(),
+                        new_version: TOKEN_VERSION,
                         new_onchain_id: self.token_onchain_id.read(),
                     },
                 );
@@ -232,7 +234,7 @@ pub mod Token {
                         new_name: self.erc20.ERC20_name.read(),
                         new_symbol: symbol,
                         new_decimals: self.token_decimals.read(),
-                        new_version: self.token_version.read(),
+                        new_version: TOKEN_VERSION,
                         new_onchain_id: self.token_onchain_id.read(),
                     },
                 );
@@ -247,7 +249,7 @@ pub mod Token {
                         new_name: self.erc20.ERC20_name.read(),
                         new_symbol: self.erc20.ERC20_symbol.read(),
                         new_decimals: self.token_decimals.read(),
-                        new_version: self.token_version.read(),
+                        new_version: TOKEN_VERSION,
                         new_onchain_id: onchain_id,
                     },
                 );
@@ -468,8 +470,8 @@ pub mod Token {
             self.token_onchain_id.read()
         }
 
-        fn version(self: @ContractState) -> ByteArray {
-            self.token_version.read()
+        fn version(self: @ContractState) -> felt252 {
+            TOKEN_VERSION
         }
 
         fn identity_registry(self: @ContractState) -> IIdentityRegistryDispatcher {

--- a/crates/token/src/token.cairo
+++ b/crates/token/src/token.cairo
@@ -589,7 +589,7 @@ pub mod Token {
 
     impl SNIP12MetadataImpl of SNIP12Metadata {
         fn name() -> felt252 {
-            'TREX_TOKEN'
+            'ERC3643_TOKEN'
         }
 
         fn version() -> felt252 {

--- a/crates/token/src/token.cairo
+++ b/crates/token/src/token.cairo
@@ -587,7 +587,7 @@ pub mod Token {
         }
     }
 
-    impl SNIP12MetadataImpl of SNIP12Metadata {
+    pub impl SNIP12MetadataImpl of SNIP12Metadata {
         fn name() -> felt252 {
             'ERC3643_TOKEN'
         }

--- a/crates/token/tests/token_transfer_test.cairo
+++ b/crates/token/tests/token_transfer_test.cairo
@@ -1379,3 +1379,78 @@ pub mod batch_burn {
             );
     }
 }
+
+pub mod permit {
+    use core::hash::{HashStateExTrait, HashStateTrait};
+    use core::poseidon::PoseidonTrait;
+    use factory::tests_common::setup_full_suite;
+    use openzeppelin_token::erc20::interface::{ERC20ABIDispatcher, ERC20ABIDispatcherTrait};
+    use openzeppelin_token::erc20::snip12_utils::permit::Permit;
+    use openzeppelin_utils::cryptography::{
+        interface::{
+            INoncesDispatcher, INoncesDispatcherTrait, ISNIP12MetadataDispatcher,
+            ISNIP12MetadataDispatcherTrait,
+        },
+        snip12::{StarknetDomain, StructHash},
+    };
+    use snforge_std::{
+        signature::{SignerTrait, stark_curve::StarkCurveSignerImpl}, start_cheat_caller_address,
+        stop_cheat_caller_address,
+    };
+
+    #[test]
+    fn test_should_approve_via_permit_then_transfer_tokens_via_transfer_from() {
+        let setup = setup_full_suite();
+        let sender = setup.accounts.alice.account.contract_address;
+        let spender = starknet::contract_address_const::<'SPENDER'>();
+        let recipient = setup.accounts.bob.account.contract_address;
+        let token = setup.token.contract_address;
+        let amount = 100;
+        /// Current time + DAY
+        let deadline = starknet::get_block_timestamp() + 60 * 60 * 24;
+
+        /// Construct and Sign Permit Data
+        let snip12_metadata_dispatcher = ISNIP12MetadataDispatcher {
+            contract_address: setup.token.contract_address,
+        };
+        let (name, version) = snip12_metadata_dispatcher.snip12_metadata();
+        let sn_domain = StarknetDomain {
+            name: name,
+            version: version,
+            chain_id: starknet::get_tx_info().unbox().chain_id,
+            revision: 1,
+        };
+        let nonces_dispatcher = INoncesDispatcher { contract_address: token };
+        let nonce = nonces_dispatcher.nonces(sender);
+        let permit = Permit { token, spender, amount, nonce, deadline };
+        let msg_hash = PoseidonTrait::new()
+            .update_with('StarkNet Message')
+            .update_with(sn_domain.hash_struct())
+            .update_with(sender)
+            .update_with(permit.hash_struct())
+            .finalize();
+
+        let (r, s) = setup.accounts.alice.key_pair.sign(msg_hash).unwrap();
+        let permit_sig = array![r, s].span();
+
+        let erc20_dispatcher = ERC20ABIDispatcher { contract_address: token };
+        let sender_balance_prev = erc20_dispatcher.balance_of(sender);
+        let recipient_balance_prev = erc20_dispatcher.balance_of(recipient);
+
+        start_cheat_caller_address(token, spender);
+        erc20_dispatcher.permit(sender, spender, amount, deadline, permit_sig);
+        assert(erc20_dispatcher.allowance(sender, spender) == amount, 'Not approved via permit');
+        erc20_dispatcher.transfer_from(sender, recipient, amount);
+        stop_cheat_caller_address(token);
+
+        assert(erc20_dispatcher.allowance(sender, spender) == 0, 'Allowance not reduced');
+        assert(
+            erc20_dispatcher.balance_of(sender) == sender_balance_prev - amount,
+            'Balance mismatch!',
+        );
+        assert(
+            erc20_dispatcher.balance_of(recipient) == recipient_balance_prev + amount,
+            'Balance mismatch!',
+        );
+    }
+}


### PR DESCRIPTION
- Added Permit Functionality to token
- Added minimal test to token transfer test that demonstrates approval via Permit and transfer from
- Changed type of `Version` on token to `ByteArray` to `const felt252`, with upgrades we can change that const value, reference repo uses `const string`, I convert `ByteArray` to `felt252` cuz to represent `version` short-string should be enough